### PR TITLE
Caching of decrypted files

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,21 @@
 version = 4
 
 [[package]]
+name = "addr2line"
+version = "0.24.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dfbe277e56a376000877090da837660b4427aad530e3028d44e0bffe4f89a1c1"
+dependencies = [
+ "gimli",
+]
+
+[[package]]
+name = "adler2"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
+
+[[package]]
 name = "aead"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -105,10 +120,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69f7f8c3906b62b754cd5326047894316021dcfe5a194c8ea52bdd94934a3457"
 
 [[package]]
+name = "async-trait"
+version = "0.1.85"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f934833b4b7233644e5848f235df3f57ed8c80f1528a26c3dfa13d2147fa056"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
+
+[[package]]
+name = "backtrace"
+version = "0.3.74"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d82cb332cdfaed17ae235a638438ac4d4839913cc2af585c3c6746e8f8bee1a"
+dependencies = [
+ "addr2line",
+ "cfg-if",
+ "libc",
+ "miniz_oxide",
+ "object",
+ "rustc-demangle",
+ "windows-targets",
+]
 
 [[package]]
 name = "base64"
@@ -187,6 +228,12 @@ name = "byteorder"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
+name = "bytes"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "325918d6fe32f23b19878fe4b34794ae41fc19ddbe53b10571a4874d44ffd39b"
 
 [[package]]
 name = "cbc"
@@ -572,10 +619,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "gimli"
+version = "0.31.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
+
+[[package]]
 name = "hashbrown"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+
+[[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hkdf"
@@ -764,6 +823,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
+name = "miniz_oxide"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ffbe83022cedc1d264172192511ae958937694cd57ce297164951b8b3568394"
+dependencies = [
+ "adler2",
+]
+
+[[package]]
 name = "nix-rage"
 version = "0.1.0"
 dependencies = [
@@ -771,6 +839,9 @@ dependencies = [
  "anyhow",
  "cc",
  "pkg-config",
+ "sha256",
+ "tempfile",
+ "users",
 ]
 
 [[package]]
@@ -828,6 +899,15 @@ checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
  "libm",
+]
+
+[[package]]
+name = "object"
+version = "0.36.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62948e14d923ea95ea2c7c86c71013138b66525b86bdc08d2dcc262bdb497b87"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -1100,6 +1180,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustc-demangle"
+version = "0.1.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
+
+[[package]]
 name = "rustc-hash"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1224,6 +1310,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha256"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18278f6a914fa3070aa316493f7d2ddfb9ac86ebc06fa3b83bffda487e9065b0"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "hex",
+ "sha2",
+ "tokio",
+]
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1295,12 +1394,13 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.14.0"
+version = "3.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28cce251fcbc87fac86a866eeb0d6c2d536fc16d06f184bb61aeae11aa4cee0c"
+checksum = "9a8a559c81686f576e8cd0290cd2a24a2a9ad80c98b3478856500fcbd7acd704"
 dependencies = [
  "cfg-if",
  "fastrand",
+ "getrandom",
  "once_cell",
  "rustix",
  "windows-sys 0.59.0",
@@ -1333,6 +1433,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9117f5d4db391c1cf6927e7bea3db74b9a1c1add8f7eda9ffd5364f40f57b82f"
 dependencies = [
  "displaydoc",
+]
+
+[[package]]
+name = "tokio"
+version = "1.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5cec9b21b0450273377fc97bd4c33a8acffc8c996c987a7c5b319a0083707551"
+dependencies = [
+ "backtrace",
+ "bytes",
+ "pin-project-lite",
 ]
 
 [[package]]
@@ -1392,6 +1503,16 @@ checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
 dependencies = [
  "crypto-common",
  "subtle",
+]
+
+[[package]]
+name = "users"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24cc0f6d6f267b73e5a2cadf007ba8f9bc39c6a6f9666f8cf25ea809a153b032"
+dependencies = [
+ "libc",
+ "log",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,9 @@ crate-type = ["cdylib"]
 [dependencies]
 age = { version = "0.11", features = ["armor", "plugin", "ssh"] }
 anyhow = "1.0"
+sha256 = "1.5.0"
+tempfile = "3.15.0"
+users = "0.11.0"
 
 [build-dependencies]
 cc = "1.0"

--- a/plugin.cpp
+++ b/plugin.cpp
@@ -8,7 +8,7 @@ using namespace nix;
 
 extern "C" {
 char *nix_rage_decrypt(const char **identities, size_t size,
-                       const char *filename);
+                       const char *filename, bool cache, const char *cache_dir);
 char *nix_rage_decrypt_error();
 }
 
@@ -17,6 +17,9 @@ char *decrypt_content(EvalState &state, const PosIdx pos, Value **args) {
       *args[0], pos,
       "while evaluating the first argument passed to 'builtins.importAge'");
   state.forceValue(*args[1], pos);
+  state.forceAttrs(
+      *args[2], pos,
+      "while evaluating the first argument passed to 'builtins.importAge'");
 
   if (args[1]->type() != nPath) {
     state
@@ -42,8 +45,25 @@ char *decrypt_content(EvalState &state, const PosIdx pos, Value **args) {
     identities.push_back(const_cast<const char *>(path));
   }
 
-  auto content =
-      nix_rage_decrypt(identities.data(), identities.size(), filename);
+  auto cache_value = args[2]->attrs()->get(state.symbols.create("cache"));
+  bool cache = true;
+  if (cache_value) {
+    cache = cache_value->value->boolean();
+  }
+  auto cache_dir_value_ref =
+      args[2]->attrs()->get(state.symbols.create("cache_dir"));
+  const char *cache_dir = NULL;
+  if (cache_dir_value_ref) {
+    Value *cache_dir_value = cache_dir_value_ref->value;
+    if (cache_dir_value->type() != nPath) {
+      cache_dir =
+          const_cast<const char *>(cache_dir_value->path().path.c_str());
+    } else if (cache_dir_value->type() != nString) {
+      cache_dir = const_cast<const char *>(cache_dir_value->c_str());
+    }
+  }
+  auto content = nix_rage_decrypt(identities.data(), identities.size(),
+                                  filename, cache, cache_dir);
   if (!content) {
     auto err = nix_rage_decrypt_error();
     if (!err) {
@@ -93,16 +113,16 @@ void prim_readAgeFile(EvalState &state, const PosIdx pos, Value **args,
 static std::vector<RegisterPrimOp> primops = std::vector{
     nix::RegisterPrimOp((nix::PrimOp){
         .name = "importAge",
-        .args = {"identities", "path"},
-        .arity = 2,
+        .args = {"identities", "path", "configs"},
+        .arity = 3,
         .doc = "Import encypted .nix file",
         .fun = prim_importAge,
         .experimentalFeature = {},
     }),
     nix::RegisterPrimOp((nix::PrimOp){
         .name = "readAgeFile",
-        .args = {"identities", "path"},
-        .arity = 2,
+        .args = {"identities", "path", "configs"},
+        .arity = 3,
         .doc = "Read encrypted file",
         .fun = prim_readAgeFile,
         .experimentalFeature = {},

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,11 +1,17 @@
 use age::{Decryptor, Identity, IdentityFile};
 use anyhow::Result;
+use sha256::digest;
 use std::ffi::{CStr, CString};
 use std::fs;
-use std::io::Read;
-use std::os::raw::c_char;
-use std::path::Path;
+use std::io::{Read, Write};
+use std::ops::Not;
+use std::os::{
+    raw::c_char,
+    unix::fs::{OpenOptionsExt, PermissionsExt},
+};
+use std::path::{Path, PathBuf};
 use std::ptr;
+use users::get_current_uid;
 
 fn decrypt_file<'a>(
     identities: impl Iterator<Item = &'a dyn Identity>,
@@ -19,7 +25,96 @@ fn decrypt_file<'a>(
     Ok(content)
 }
 
-fn _nix_rage_decrypt(identities: Vec<&str>, filename: &str) -> Result<String> {
+#[derive(Debug)]
+struct DecryptCache {
+    cache_dir: PathBuf,
+}
+
+impl Default for DecryptCache {
+    fn default() -> Self {
+        let mut cache_dir = tempfile::env::temp_dir();
+        cache_dir.push("nix-rage-cache");
+        Self { cache_dir }
+    }
+}
+
+impl DecryptCache {
+    fn new<P: AsRef<Path>>(cache_dir: P) -> Self {
+        Self {
+            cache_dir: cache_dir.as_ref().to_path_buf(),
+        }
+    }
+
+    fn user_cache_path(&self, uid: u32) -> std::path::PathBuf {
+        let mut cache_path = self.cache_dir.clone();
+        cache_path.push(uid.to_string());
+        cache_path
+    }
+
+    fn make_user_cache_path(&self, uid: u32) -> Result<()> {
+        let base_cache_path = &self.cache_dir;
+        if !fs::exists(base_cache_path)? {
+            fs::create_dir_all(base_cache_path)?;
+            let mut perms = fs::metadata(base_cache_path)?.permissions();
+            perms.set_mode(0o777);
+            fs::set_permissions(base_cache_path, perms)?;
+        }
+        let user_cache_path = self.user_cache_path(uid);
+        if !fs::exists(&user_cache_path)? {
+            fs::create_dir_all(&user_cache_path)?;
+            let mut perms = fs::metadata(&user_cache_path)?.permissions();
+            perms.set_mode(0o700);
+            fs::set_permissions(&user_cache_path, perms)?;
+        }
+        Ok(())
+    }
+
+    fn gen_cache_path<P: AsRef<Path>>(&self, path: P, uid: u32) -> std::path::PathBuf {
+        let cache_filename = path
+            .as_ref()
+            .to_str()
+            .map(digest)
+            .and_then(|f| {
+                path.as_ref()
+                    .file_name()
+                    .and_then(|n| n.to_str())
+                    .map(|n| format!("{f}-{n}"))
+            })
+            .expect("Incorrect file path!");
+        let mut cache_path = self.user_cache_path(uid);
+        cache_path.push(cache_filename);
+        cache_path
+    }
+
+    fn cache<P: AsRef<Path>>(&self, path: P, content: &str) -> Result<()> {
+        let uid = get_current_uid();
+        let cache_path = self.gen_cache_path(path, uid);
+        self.make_user_cache_path(uid)?;
+        let mut output = fs::OpenOptions::new()
+            .truncate(true)
+            .create(true)
+            .write(true)
+            .mode(0o700)
+            .open(cache_path)?;
+        write!(output, "{}", content)?;
+        Ok(())
+    }
+
+    fn load<P: AsRef<Path>>(&self, path: P) -> Result<Option<String>> {
+        let uid = get_current_uid();
+        let cache_path = self.gen_cache_path(path, uid);
+        if fs::exists(&cache_path)? {
+            return Ok(Some(fs::read_to_string(&cache_path)?));
+        }
+        Ok(None)
+    }
+}
+
+fn _nix_rage_decrypt(
+    identities: Vec<&str>,
+    filename: &str,
+    cache: Option<DecryptCache>,
+) -> Result<String> {
     let identities = identities
         .into_iter()
         .map(&str::to_string)
@@ -28,7 +123,16 @@ fn _nix_rage_decrypt(identities: Vec<&str>, filename: &str) -> Result<String> {
         .flatten()
         .collect::<Vec<_>>();
     let filename = Path::new(filename);
-    decrypt_file(identities.iter().map(|b| &**b), filename)
+    if let Some(cache) = &cache {
+        if let Some(content) = cache.load(filename)? {
+            return Ok(content);
+        }
+    }
+    let content = decrypt_file(identities.iter().map(|b| &**b), filename)?;
+    if let Some(cache) = &cache {
+        cache.cache(filename, &content)?;
+    }
+    Ok(content)
 }
 
 static mut DECRYPT_ERROR: Option<String> = None;
@@ -57,19 +161,34 @@ pub unsafe extern "C" fn nix_rage_decrypt(
     identities: *const *const c_char,
     size: usize,
     filename: *const c_char,
+    cache: bool,
+    cache_dir: *const c_char,
 ) -> *const c_char {
-    let fname = unsafe { CStr::from_ptr(filename) }.to_str();
+    let fname = unsafe { CStr::from_ptr(filename) }.to_str().ok();
+    let cache_dir = cache_dir
+        .is_null()
+        .not()
+        .then(|| unsafe { CStr::from_ptr(cache_dir) })
+        .map(CStr::to_str)
+        .and_then(Result::ok);
     let identities = unsafe { std::slice::from_raw_parts(identities, size) }
         .iter()
         .map(|ptr| unsafe { CStr::from_ptr(*ptr) }.to_str())
-        .collect::<Result<Vec<_>, _>>();
+        .collect::<Result<Vec<_>, _>>()
+        .ok();
     identities
-        .ok()
-        .and_then(|i| {
-            fname
+        .and_then(|i| fname.map(|f| (i, f)))
+        .map(|(i, f)| {
+            (
+                i,
+                f,
+                cache.then(|| cache_dir.map(DecryptCache::new).unwrap_or_default()),
+            )
+        })
+        .and_then(|(i, f, c)| {
+            _nix_rage_decrypt(i, f, c)
+                .map_err(|err| set_error(err.to_string()))
                 .ok()
-                .map(|f| _nix_rage_decrypt(i, f))
-                .and_then(|r| r.map_err(|err| set_error(err.to_string())).ok())
         })
         .and_then(|content| CString::new(content).ok())
         .map(|content| content.into_raw() as *const c_char)


### PR DESCRIPTION
Added the ability to cache decrypted files. The default directory is `/tmp/nix-rage-cache/<uid>/<path-hash>-<name>`.
This option does not track changes to the file. Right now it is assumed to be in `/nix/store` and the path will change when the file is changed.