### PR TITLE
fix: missing eval.hh and primops.hh

### DIFF
--- a/plugin.cpp
+++ b/plugin.cpp
@@ -1,7 +1,7 @@
 /* #include <config.h> */
-#include <eval.hh>
+#include <nix/expr/eval.hh>
 #include <format>
-#include <primops.hh>
+#include <nix/expr/primops.hh>
 #include <vector>
 
 using namespace nix;


### PR DESCRIPTION
After updating to last nix versions, some headers have moved. and nix-rage won't compile anymore.