### PR TITLE
fix: nix-darwin plugin compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,14 +20,16 @@ You need to add plugin-files inside you `nix.conf` (`~/.config/nix/nix.conf`, `/
 
 ```
 # with nix-env:
-plugin-files = /home/YOURUSERNAMEHERE/.nix-profile/lib/libnix_doc_plugin.so
+plugin-files = /home/YOURUSERNAMEHERE/.nix-profile/lib/libnix_rage.<so|dylib>
 
-# with cago build:
-plugin-files = /path/to/repo/target/debug/libnix_rage.so
+# with cargo build:
+plugin-files = /path/to/repo/target/debug/libnix_rage.<so|dylib>
 
 # inside nix config:
-plugin-files = ${pkgs.nix-rage}/lib/libnix_rage.so
+plugin-files = ${pkgs.nix-rage}/lib/libnix_rage${pkgs.stdenv.hostPlatform.extensions.sharedLibrary}
 ```
+
+When using the flake package, `packages.<system>.default` follows the Nix version of the evaluator running the build via `builtins.nixVersion`. This matters for `darwin-rebuild` and similar bootstraps, where the current system Nix may lag behind the target `pkgs.nix`.
 
 Nix Flake example:
 
@@ -45,13 +47,13 @@ Nix Flake example:
       myhostname = nixpkgs.lib.nixosSystem {
         system = "x86_64-linux";
         modules = [
-          {
+          ({ pkgs, ... }: {
             nix.extraOptions = let
               nix-rage-package = nix-rage.packages."x86_64-linux".default;
             in ''
-              plugin-files = ${nix-rage-package}/lib/libnix_rage.so
+              plugin-files = ${nix-rage-package}/lib/libnix_rage${pkgs.stdenv.hostPlatform.extensions.sharedLibrary}
             '';
-          }
+          })
           #...
         ];
       };
@@ -133,4 +135,3 @@ You might also be interested in:
 ## License
 
 nix-rage is licensed under the MIT License. See the [LICENSE](LICENSE) file for more information.
-

--- a/build.rs
+++ b/build.rs
@@ -5,19 +5,19 @@ trait AddPkg {
 impl AddPkg for cc::Build {
     fn add_pkg_config(&mut self, pkg: pkg_config::Library) -> &mut Self {
         for p in pkg.include_paths.into_iter() {
-            self.flag("-isystem").flag(p.to_str().unwrap());
+            self.include(p);
         }
         for p in pkg.link_paths.into_iter() {
-            self.flag(format!("-L{:?}", p));
+            self.flag("-L").flag(p.to_str().unwrap());
         }
         for p in pkg.libs.into_iter() {
             self.flag(format!("-l{}", p));
         }
         for p in pkg.framework_paths.into_iter() {
-            self.flag(format!("-F{:?}", p));
+            self.flag("-F").flag(p.to_str().unwrap());
         }
         for p in pkg.frameworks.into_iter() {
-            self.flag(format!("-framework {}", p));
+            self.flag("-framework").flag(&p);
         }
         self
     }
@@ -90,7 +90,7 @@ fn main() {
         .cpp(true)
         .opt_level(2)
         .shared_flag(true)
-        .std("c++20")
+        .std("c++23")
         .add_pkg_config(nix_expr)
         .add_pkg_config(nix_store)
         .add_pkg_config(nix_main)

--- a/flake.nix
+++ b/flake.nix
@@ -33,6 +33,8 @@
         lib,
         ...
       }: let
+        normalizeNixVersion = version: lib.head (lib.splitString "+" version);
+        evaluatorNixVersion = normalizeNixVersion builtins.nixVersion;
         toolchain = pkgs.fenix.stable.withComponents [
           "cargo"
           "clippy"
@@ -47,6 +49,16 @@
           && (builtins.tryEval nix_pkg).success
           && builtins.compareVersions nix_pkg.version "2.24" >= 0)
         pkgs.nixVersions;
+        evaluator_nix_pkgs = builtins.attrValues (lib.filterAttrs (_: nix_pkg:
+          normalizeNixVersion nix_pkg.version == evaluatorNixVersion)
+        nix_pkgs);
+        evaluator_nix_pkg =
+          if evaluator_nix_pkgs != [] then
+            builtins.head evaluator_nix_pkgs
+          else
+            null;
+        sharedLibraryName = pkg:
+          "${lib.getLib pkg}/lib/libnix_rage${pkgs.stdenv.hostPlatform.extensions.sharedLibrary}";
         commonArgs = nix_pkg: {
           src = lib.cleanSourceWith {
             src = lib.cleanSource ./.;
@@ -149,7 +161,7 @@
                 nodes.machine1 = {
                   nix.package = nix_pkg;
                   nix.extraOptions = ''
-                    plugin-files = ${self'.packages."nix-rage-nix-${nix_version}"}/lib/libnix_rage.so
+                    plugin-files = ${sharedLibraryName self'.packages."nix-rage-nix-${nix_version}"}
                     experimental-features = nix-command
                   '';
                 };
@@ -210,7 +222,12 @@
           })
           nix_pkgs
           // {
-            nix-rage = self'.packages.nix-rage-nix-stable;
+            nix-rage-current =
+              if evaluator_nix_pkg != null then
+                nix-rage evaluator_nix_pkg
+              else
+                self'.packages.nix-rage-nix-stable;
+            nix-rage = self'.packages.nix-rage-current;
             default = self'.packages.nix-rage;
           };
       };

--- a/plugin.cpp
+++ b/plugin.cpp
@@ -92,6 +92,33 @@ char *decrypt_content(EvalState &state, const PosIdx pos, Value **args) {
   return content;
 }
 
+static nix::PrimOp make_primop(const char *name,
+                               std::initializer_list<std::string> args,
+                               const char *doc, nix::PrimOpFun *impl) {
+#if NIX_VERSION_GE(2, 34, 00)
+  nix::PrimOp primop{
+      .name = name,
+      .args = args,
+      .arity = args.size(),
+      .doc = doc,
+      .addTrace = true,
+      .impl = impl,
+      .experimentalFeature = {},
+      .internal = false,
+  };
+#else
+  nix::PrimOp primop{
+      .name = name,
+      .args = args,
+      .arity = args.size(),
+      .doc = doc,
+      .fun = impl,
+      .experimentalFeature = {},
+  };
+#endif
+  return primop;
+}
+
 void prim_importAge(EvalState &state, const PosIdx pos, Value **args,
                     Value &v) {
   auto content = decrypt_content(state, pos, args);
@@ -123,24 +150,18 @@ void prim_readAgeFile(EvalState &state, const PosIdx pos, Value **args,
   if (!content) {
     throw Error("decrypt error while evaluation");
   };
+#if NIX_VERSION_GE(2, 34, 00)
+  v.mkString(content, state.mem);
+#else
   v.mkString(content);
+#endif
 }
 
 static std::vector<RegisterPrimOp> primops = std::vector{
-    nix::RegisterPrimOp(nix::PrimOp{
-        .name = "importAge",
-        .args = {"identities", "path", "configs"},
-        .arity = 3,
-        .doc = "Import encypted .nix file",
-        .fun = prim_importAge,
-        .experimentalFeature = {},
-    }),
-    nix::RegisterPrimOp(nix::PrimOp{
-        .name = "readAgeFile",
-        .args = {"identities", "path", "configs"},
-        .arity = 3,
-        .doc = "Read encrypted file",
-        .fun = prim_readAgeFile,
-        .experimentalFeature = {},
-    }),
+    nix::RegisterPrimOp(make_primop(
+        "importAge", {"identities", "path", "configs"},
+        "Import encypted .nix file", prim_importAge)),
+    nix::RegisterPrimOp(make_primop("readAgeFile",
+                                    {"identities", "path", "configs"},
+                                    "Read encrypted file", prim_readAgeFile)),
 };


### PR DESCRIPTION
## Summary

Fix compatibility with recent Nix versions on Darwin and avoid loading a plugin built against a different Nix evaluator version.

## What Changed

- Build the C++ plugin with `c++23`, required by newer Nix headers.
- Add compatibility for the Nix 2.34 primop API changes:
  - `PrimOp.fun` -> `PrimOp.impl`
  - `Value::mkString(...)` now requires `state.mem`
- Stop hardcoding `libnix_rage.so` and use the platform shared library extension, so Darwin uses `.dylib`.
- Make the default flake package follow `builtins.nixVersion` instead of always using `nix-rage-nix-stable`.

## Why

Nix plugins are tied to Nix’s internal C++ ABI. On nix-darwin, `darwin-rebuild` can evaluate with the currently installed Nix while the target system may use a newer `pkgs.nix`. If `nix-rage` is built against the target Nix instead of the evaluator Nix, the plugin can load but fail to register `builtins.importAge`.

This caused rebuilds to fail with:

```sh
error: attribute 'importAge' missing
```

Using the evaluator’s builtins.nixVersion for the default package keeps the plugin and evaluator aligned during rebuild bootstraps.

Verification

Tested on aarch64-darwin:
```sh
nix build .#default
darwin-rebuild switch --flake <config>#<host> --show-trace
```

The system rebuild now gets past plugin compilation and builtins.importAge is registered correctly.

Notes

Direct cargo build still requires a Nix development environment or a valid PKG_CONFIG_PATH, because the crate links against Nix internal libraries through pkg-config.